### PR TITLE
Add Blazorise styling for relaxed Memories and Miles site

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+bin/
+obj/
+*.png

--- a/App.razor
+++ b/App.razor
@@ -1,0 +1,12 @@
+﻿<Router AppAssembly="@typeof(App).Assembly">
+    <Found Context="routeData">
+        <RouteView RouteData="@routeData" DefaultLayout="@typeof(MainLayout)" />
+        <FocusOnNavigate RouteData="@routeData" Selector="h1" />
+    </Found>
+    <NotFound>
+        <PageTitle>Not found</PageTitle>
+        <LayoutView Layout="@typeof(MainLayout)">
+            <p role="alert">Sorry, there's nothing at this address.</p>
+        </LayoutView>
+    </NotFound>
+</Router>

--- a/Layout/MainLayout.razor
+++ b/Layout/MainLayout.razor
@@ -1,0 +1,23 @@
+@inherits LayoutComponentBase
+
+<ThemeProvider Theme="theme">
+    <NavMenu />
+    <Container Class="mt-4">
+        @Body
+    </Container>
+</ThemeProvider>
+
+@code {
+    Theme theme = new()
+    {
+        ColorOptions = new()
+        {
+            Primary = "#6fa7c7",
+            Secondary = "#a3d2ca"
+        },
+        BackgroundOptions = new()
+        {
+            Body = "#f0f9ff"
+        }
+    };
+}

--- a/Layout/NavMenu.razor
+++ b/Layout/NavMenu.razor
@@ -1,0 +1,21 @@
+<Bar Background="Background.Light" ThemeContrast="ThemeContrast.Light">
+    <BarBrand>
+        <BarItem>
+            <BarLink Class="navbar-brand" To="">Memories and Miles</BarLink>
+        </BarItem>
+    </BarBrand>
+    <BarToggler Clicked="@ToggleBar" />
+    <BarMenu Visible="@barVisible">
+        <BarStart>
+            <BarItem><BarLink To="">Home</BarLink></BarItem>
+            <BarItem><BarLink To="questionnaire">Questionnaire</BarLink></BarItem>
+            <BarItem><BarLink To="contact">Contact</BarLink></BarItem>
+        </BarStart>
+    </BarMenu>
+</Bar>
+
+@code {
+    bool barVisible;
+
+    void ToggleBar() => barVisible = !barVisible;
+}

--- a/Pages/Contact.razor
+++ b/Pages/Contact.razor
@@ -1,0 +1,45 @@
+@page "/contact"
+
+@inject NavigationManager Navigation
+
+<PageTitle>Contact</PageTitle>
+
+<h1>Contact Memories and Miles</h1>
+
+<p>Have questions or ready to start planning your trip? Send us a message!</p>
+
+<EditForm Model="form" OnValidSubmit="SendEmail">
+    <DataAnnotationsValidator />
+    <Field>
+        <FieldLabel>Name</FieldLabel>
+        <TextEdit @bind-Text="form.Name" />
+    </Field>
+    <Field>
+        <FieldLabel>Email</FieldLabel>
+        <TextEdit @bind-Text="form.Email" />
+    </Field>
+    <Field>
+        <FieldLabel>Message</FieldLabel>
+        <MemoEdit @bind-Text="form.Message" />
+    </Field>
+    <Button Color="Color.Primary" Type="ButtonType.Submit">Send Email</Button>
+</EditForm>
+
+@code {
+    private ContactForm form = new();
+
+    private void SendEmail()
+    {
+        var subject = Uri.EscapeDataString($"Travel Inquiry from {form.Name}");
+        var body = Uri.EscapeDataString($"{form.Message}\n\nContact: {form.Email}");
+        var mailto = $"mailto:laura@whitneyworldtravel.com?subject={subject}&body={body}";
+        Navigation.NavigateTo(mailto, forceLoad: true);
+    }
+
+    private class ContactForm
+    {
+        public string? Name { get; set; }
+        public string? Email { get; set; }
+        public string? Message { get; set; }
+    }
+}

--- a/Pages/Home.razor
+++ b/Pages/Home.razor
@@ -1,0 +1,11 @@
+﻿@page "/"
+
+<PageTitle>Memories and Miles</PageTitle>
+
+<Card>
+    <CardBody>
+        <CardTitle>Welcome to Memories and Miles</CardTitle>
+        <CardText>Your travel planning partner specializing in magical Disney vacations, Universal adventures, and unforgettable cruises.</CardText>
+        <CardText><NavLink href="questionnaire">Use our quick questionnaire</NavLink> to discover your next destination or <NavLink href="contact">contact us</NavLink> for personalized help.</CardText>
+    </CardBody>
+</Card>

--- a/Pages/Questionnaire.razor
+++ b/Pages/Questionnaire.razor
@@ -1,0 +1,87 @@
+@page "/questionnaire"
+
+<PageTitle>Trip Questionnaire</PageTitle>
+
+<h1>Find Your Next Adventure</h1>
+
+@if (result == null)
+{
+    <EditForm Model="model" OnValidSubmit="HandleSubmit">
+        <DataAnnotationsValidator />
+        <Field>
+            <FieldLabel>What kind of trip are you looking for?</FieldLabel>
+            <Select TValue="string" @bind-SelectedValue="model.TripKind" Placeholder="Select...">
+                <SelectItem Value="@("themepark")">Theme Park</SelectItem>
+                <SelectItem Value="@("cruise")">Cruise</SelectItem>
+            </Select>
+        </Field>
+        @if (model.TripKind == "themepark")
+        {
+            <Field>
+                <FieldLabel>Which destination interests you most?</FieldLabel>
+                <Select TValue="string" @bind-SelectedValue="model.ThemePark" Placeholder="Select...">
+                    <SelectItem Value="@("DisneyWorld")">Walt Disney World</SelectItem>
+                    <SelectItem Value="@("Disneyland")">Disneyland</SelectItem>
+                    <SelectItem Value="@("Universal")">Universal Studios</SelectItem>
+                </Select>
+            </Field>
+        }
+        else if (model.TripKind == "cruise")
+        {
+            <Field>
+                <FieldLabel>Which cruise line sounds best?</FieldLabel>
+                <Select TValue="string" @bind-SelectedValue="model.CruiseLine" Placeholder="Select...">
+                    <SelectItem Value="@("DisneyCruise")">Disney Cruise Line</SelectItem>
+                    <SelectItem Value="@("OtherCruise")">Other Cruise Lines</SelectItem>
+                </Select>
+            </Field>
+        }
+        <Button Color="Color.Primary" Type="ButtonType.Submit">Get Recommendation</Button>
+    </EditForm>
+}
+else
+{
+    <p>We recommend: <strong>@result</strong></p>
+    <Button Color="Color.Secondary" @onclick="Reset">Start Over</Button>
+}
+
+@code {
+    private QuestionnaireModel model = new();
+    private string? result;
+
+    private void HandleSubmit()
+    {
+        if (model.TripKind == "themepark")
+        {
+            result = model.ThemePark switch
+            {
+                "DisneyWorld" => "Walt Disney World in Florida",
+                "Disneyland" => "Disneyland Resort in California",
+                "Universal" => "Universal Studios in Orlando",
+                _ => "a theme park adventure"
+            };
+        }
+        else if (model.TripKind == "cruise")
+        {
+            result = model.CruiseLine switch
+            {
+                "DisneyCruise" => "Disney Cruise Line",
+                "OtherCruise" => "another major cruise line such as Royal Caribbean or Carnival",
+                _ => "a cruise vacation"
+            };
+        }
+    }
+
+    private void Reset()
+    {
+        model = new();
+        result = null;
+    }
+
+    private class QuestionnaireModel
+    {
+        public string? TripKind { get; set; }
+        public string? ThemePark { get; set; }
+        public string? CruiseLine { get; set; }
+    }
+}

--- a/Program.cs
+++ b/Program.cs
@@ -1,0 +1,18 @@
+using Microsoft.AspNetCore.Components.Web;
+using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
+using memoriesandmiles;
+using Blazorise;
+using Blazorise.Bootstrap5;
+using Blazorise.Icons.FontAwesome;
+
+var builder = WebAssemblyHostBuilder.CreateDefault(args);
+builder.RootComponents.Add<App>("#app");
+builder.RootComponents.Add<HeadOutlet>("head::after");
+
+builder.Services
+    .AddBlazorise(options => { options.Immediate = true; })
+    .AddBootstrap5Providers()
+    .AddFontAwesomeIcons();
+
+var host = builder.Build();
+await host.RunAsync();

--- a/Properties/launchSettings.json
+++ b/Properties/launchSettings.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "http://json.schemastore.org/launchsettings.json",
+  "iisSettings": {
+    "windowsAuthentication": false,
+    "anonymousAuthentication": true,
+    "iisExpress": {
+      "applicationUrl": "http://localhost:35260",
+      "sslPort": 0
+    }
+  },
+  "profiles": {
+    "http": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "inspectUri": "{wsProtocol}://{url.hostname}:{url.port}/_framework/debug/ws-proxy?browser={browserInspectUri}",
+      "applicationUrl": "http://localhost:5234",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "IIS Express": {
+      "commandName": "IISExpress",
+      "launchBrowser": true,
+      "inspectUri": "{wsProtocol}://{url.hostname}:{url.port}/_framework/debug/ws-proxy?browser={browserInspectUri}",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/_Imports.razor
+++ b/_Imports.razor
@@ -1,0 +1,11 @@
+﻿@using System.Net.Http
+@using System.Net.Http.Json
+@using Microsoft.AspNetCore.Components.Forms
+@using Microsoft.AspNetCore.Components.Routing
+@using Microsoft.AspNetCore.Components.Web
+@using Microsoft.AspNetCore.Components.Web.Virtualization
+@using Microsoft.AspNetCore.Components.WebAssembly.Http
+@using Microsoft.JSInterop
+@using memoriesandmiles
+@using memoriesandmiles.Layout
+@using Blazorise

--- a/memoriesandmiles.csproj
+++ b/memoriesandmiles.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk.BlazorWebAssembly">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Blazorise" Version="1.6.0" />
+    <PackageReference Include="Blazorise.Bootstrap5" Version="1.6.0" />
+    <PackageReference Include="Blazorise.Icons.FontAwesome" Version="1.6.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.19" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="8.0.19" PrivateAssets="all" />
+  </ItemGroup>
+
+</Project>

--- a/readme.md
+++ b/readme.md
@@ -1,1 +1,13 @@
-hello world
+# Memories and Miles
+
+Static Blazor WebAssembly site for planning Disney, Universal, and cruise vacations. Built with Blazorise components for a calm, laid-back feel. It includes:
+
+- Home page introducing the travel services.
+- Questionnaire to help choose a destination.
+- Contact form that opens an email to laura@whitneyworldtravel.com.
+
+Build the site:
+
+```bash
+ dotnet build
+```

--- a/wwwroot/css/app.css
+++ b/wwwroot/css/app.css
@@ -1,0 +1,104 @@
+html, body {
+    font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+    background-color: #f0f9ff;
+}
+
+h1:focus {
+    outline: none;
+}
+
+a, .btn-link {
+    color: #6fa7c7;
+}
+
+.btn-primary {
+    color: #fff;
+    background-color: #6fa7c7;
+    border-color: #6fa7c7;
+}
+
+.btn:focus, .btn:active:focus, .btn-link.nav-link:focus, .form-control:focus, .form-check-input:focus {
+  box-shadow: 0 0 0 0.1rem white, 0 0 0 0.25rem #258cfb;
+}
+
+.content {
+    padding-top: 1.1rem;
+}
+
+.valid.modified:not([type=checkbox]) {
+    outline: 1px solid #26b050;
+}
+
+.invalid {
+    outline: 1px solid red;
+}
+
+.validation-message {
+    color: red;
+}
+
+#blazor-error-ui {
+    background: lightyellow;
+    bottom: 0;
+    box-shadow: 0 -1px 2px rgba(0, 0, 0, 0.2);
+    display: none;
+    left: 0;
+    padding: 0.6rem 1.25rem 0.7rem 1.25rem;
+    position: fixed;
+    width: 100%;
+    z-index: 1000;
+}
+
+    #blazor-error-ui .dismiss {
+        cursor: pointer;
+        position: absolute;
+        right: 0.75rem;
+        top: 0.5rem;
+    }
+
+.blazor-error-boundary {
+    background: url(data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iNTYiIGhlaWdodD0iNDkiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIG92ZXJmbG93PSJoaWRkZW4iPjxkZWZzPjxjbGlwUGF0aCBpZD0iY2xpcDAiPjxyZWN0IHg9IjIzNSIgeT0iNTEiIHdpZHRoPSI1NiIgaGVpZ2h0PSI0OSIvPjwvY2xpcFBhdGg+PC9kZWZzPjxnIGNsaXAtcGF0aD0idXJsKCNjbGlwMCkiIHRyYW5zZm9ybT0idHJhbnNsYXRlKC0yMzUgLTUxKSI+PHBhdGggZD0iTTI2My41MDYgNTFDMjY0LjcxNyA1MSAyNjUuODEzIDUxLjQ4MzcgMjY2LjYwNiA1Mi4yNjU4TDI2Ny4wNTIgNTIuNzk4NyAyNjcuNTM5IDUzLjYyODMgMjkwLjE4NSA5Mi4xODMxIDI5MC41NDUgOTIuNzk1IDI5MC42NTYgOTIuOTk2QzI5MC44NzcgOTMuNTEzIDI5MSA5NC4wODE1IDI5MSA5NC42NzgyIDI5MSA5Ny4wNjUxIDI4OS4wMzggOTkgMjg2LjYxNyA5OUwyNDAuMzgzIDk5QzIzNy45NjMgOTkgMjM2IDk3LjA2NTEgMjM2IDk0LjY3ODIgMjM2IDk0LjM3OTkgMjM2LjAzMSA5NC4wODg2IDIzNi4wODkgOTMuODA3MkwyMzYuMzM4IDkzLjAxNjIgMjM2Ljg1OCA5Mi4xMzE0IDI1OS40NzMgNTMuNjI5NCAyNTkuOTYxIDUyLjc5ODUgMjYwLjQwNyA1Mi4yNjU4QzI2MS4yIDUxLjQ4MzcgMjYyLjI5NiA1MSAyNjMuNTA2IDUxWk0yNjMuNTg2IDY2LjAxODNDMjYwLjczNyA2Ni4wMTgzIDI1OS4zMTMgNjcuMTI0NSAyNTkuMzEzIDY5LjMzNyAyNTkuMzEzIDY5LjYxMDIgMjU5LjMzMiA2OS44NjA4IDI1OS4zNzEgNzAuMDg4N0wyNjEuNzk1IDg0LjAxNjEgMjY1LjM4IDg0LjAxNjEgMjY3LjgyMSA2OS43NDc1QzI2Ny44NiA2OS43MzA5IDI2Ny44NzkgNjkuNTg3NyAyNjcuODc5IDY5LjMxNzkgMjY3Ljg3OSA2Ny4xMTgyIDI2Ni40NDggNjYuMDE4MyAyNjMuNTg2IDY2LjAxODNaTTI2My41NzYgODYuMDU0N0MyNjEuMDQ5IDg2LjA1NDcgMjU5Ljc4NiA4Ny4zMDA1IDI1OS43ODYgODkuNzkyMSAyNTkuNzg2IDkyLjI4MzcgMjYxLjA0OSA5My41Mjk1IDI2My41NzYgOTMuNTI5NSAyNjYuMTE2IDkzLjUyOTUgMjY3LjM4NyA5Mi4yODM3IDI2Ny4zODcgODkuNzkyMSAyNjcuMzg3IDg3LjMwMDUgMjY2LjExNiA4Ni4wNTQ3IDI2My41NzYgODYuMDU0N1oiIGZpbGw9IiNGRkU1MDAiIGZpbGwtcnVsZT0iZXZlbm9kZCIvPjwvZz48L3N2Zz4=) no-repeat 1rem/1.8rem, #b32121;
+    padding: 1rem 1rem 1rem 3.7rem;
+    color: white;
+}
+
+    .blazor-error-boundary::after {
+        content: "An error has occurred."
+    }
+
+.loading-progress {
+    position: relative;
+    display: block;
+    width: 8rem;
+    height: 8rem;
+    margin: 20vh auto 1rem auto;
+}
+
+    .loading-progress circle {
+        fill: none;
+        stroke: #e0e0e0;
+        stroke-width: 0.6rem;
+        transform-origin: 50% 50%;
+        transform: rotate(-90deg);
+    }
+
+        .loading-progress circle:last-child {
+            stroke: #6fa7c7;
+            stroke-dasharray: calc(3.141 * var(--blazor-load-percentage, 0%) * 0.8), 500%;
+            transition: stroke-dasharray 0.05s ease-in-out;
+        }
+
+.loading-progress-text {
+    position: absolute;
+    text-align: center;
+    font-weight: bold;
+    inset: calc(20vh + 3.25rem) 0 auto 0.2rem;
+}
+
+    .loading-progress-text:after {
+        content: var(--blazor-load-percentage-text, "Loading");
+    }
+
+code {
+    color: #c02d76;
+}

--- a/wwwroot/index.html
+++ b/wwwroot/index.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Memories and Miles Travel</title>
+    <base href="/" />
+    <link rel="stylesheet" href="_content/Blazorise/blazorise.css" />
+    <link rel="stylesheet" href="_content/Blazorise.Bootstrap5/bootstrap5.css" />
+    <link rel="stylesheet" href="_content/Blazorise.Icons.FontAwesome/font-awesome.css" />
+    <link rel="stylesheet" href="css/app.css" />
+    <link href="memoriesandmiles.styles.css" rel="stylesheet" />
+</head>
+
+<body>
+    <div id="app">
+        <svg class="loading-progress">
+            <circle r="40%" cx="50%" cy="50%" />
+            <circle r="40%" cx="50%" cy="50%" />
+        </svg>
+        <div class="loading-progress-text"></div>
+    </div>
+
+    <div id="blazor-error-ui">
+        An unhandled error has occurred.
+        <a href="" class="reload">Reload</a>
+        <a class="dismiss">🗙</a>
+    </div>
+    <script src="_framework/blazor.webassembly.js"></script>
+    <script src="_content/Blazorise/blazorise.js"></script>
+    <script src="_content/Blazorise.Bootstrap5/bootstrap5.js"></script>
+    <script src="_content/Blazorise.Icons.FontAwesome/font-awesome.js"></script>
+</body>
+
+</html>


### PR DESCRIPTION
## Summary
- use Blazorise components and theme provider for a calm layout
- convert navigation, questionnaire, and contact form to Blazorise
- include Blazorise resources and soft color palette
- remove binary image assets and ignore PNG files

## Testing
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_68a8b2df2fc88328952a2cc1341e44d9